### PR TITLE
hw(4): Add tests on generated llvm labels

### DIFF
--- a/04/nicdard.ml
+++ b/04/nicdard.ml
@@ -33,6 +33,10 @@ let easy_tests =
   ; ("arlocal1.oat", "", "15")
   ; ("arlocal2.oat", "", "0")
   ; ("arlocal3.oat", "", "3")
+  ; ("if.oat", "", "3")
+  ; ("function.oat", "", "1")
+  ; ("whileterminator1.oat", "", "10")
+  ; ("whileterminator2.oat", "", "0")
   ]
 
 let nicdard_tests = Gradedtests.executed_oat_file @@ prefix easy_tests

--- a/04/nicdard/function.oat
+++ b/04/nicdard/function.oat
@@ -1,0 +1,23 @@
+int program (int argc, string[] argv) {
+    var x = abs2();
+    x = x + abs();
+    return x;
+}
+
+int abs() {
+    if (true) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+int abs2() {
+    if (true) {
+        return 0;
+    } else if (false) {
+        return 1;
+    } else {
+        return 7;
+    }
+}

--- a/04/nicdard/if.oat
+++ b/04/nicdard/if.oat
@@ -1,0 +1,42 @@
+int program(int argc, string[] argv) {
+
+    if (false) {
+        return 1;
+    }
+
+    if (false) {
+        return 2;
+    } else {
+        return 3;
+    }
+
+    if (false) {
+        return 4;
+    } else if (true) {
+        return 5;
+    }
+
+    if (false) {
+        return 6;
+    } else {
+        if (true) {
+            return 7;
+        } else {
+            return 8;
+        }
+    }
+
+    if (false) {
+        if (true) {
+            return 9;
+        } else {
+            return 10;
+        }
+    } else {
+        if (true) {
+            return 71;
+        } else {
+            return 12;
+        }
+    }
+}

--- a/04/nicdard/whileterminator1.oat
+++ b/04/nicdard/whileterminator1.oat
@@ -1,0 +1,6 @@
+int program (int argc, string[] argv) {
+    while (false) {
+        return 0;
+    }
+    return 10;
+}

--- a/04/nicdard/whileterminator2.oat
+++ b/04/nicdard/whileterminator2.oat
@@ -1,0 +1,6 @@
+int program (int argc, string[] argv) {
+    while (true) {
+        return 0;
+    }
+    return 10;
+}


### PR DESCRIPTION
I have tried to write some more tests which would trigger corner cases in the generated llvm code with respect to label usage.

I would also like discuss if you need the final return statement in the *whileterminator* tests. Actually I don't think they would be valid oat programs without it, even when the guard of the loop is true. If I am not wrong, detecting this type of things would require some control flow analysis, which I think is not part of this assignment.