### PR TITLE
Global prefix variable for easier including in multiple projects

### DIFF
--- a/03/dbernhard.ml
+++ b/03/dbernhard.ml
@@ -1,5 +1,5 @@
 
-let prefix = "./compiler-design-eth-tests/03/dbernhard/"
+let prefix = Test_config.global_prefix ^ "./compiler-design-eth-tests/03/dbernhard/"
 
 let dbernhard_tests = [
     prefix ^ "load_simple.ll", 23L

--- a/03/haenniro.ml
+++ b/03/haenniro.ml
@@ -1,6 +1,6 @@
 open Assert
 
-let prefix = "./compiler-design-eth-tests/03/haenniro/"
+let prefix = Test_config.global_prefix ^ "./compiler-design-eth-tests/03/haenniro/"
 
 let my_tests =
 (* Warning 1: The first test works only on Linux as it contains raw assembly with invalid labels. To make it work on mac, change the labels in stacktest_asm.s to have an underscore in front of them.*)

--- a/03/nicdard.ml
+++ b/03/nicdard.ml
@@ -27,7 +27,7 @@ let executed tests =
 
 (* Add prefix to tests *)
 let prefix = List.map (fun (fname, expected_result) -> 
-  ("./compiler-design-eth-tests/03/nicdard/" ^ fname, expected_result))
+  (Test_config.global_prefix ^ "./compiler-design-eth-tests/03/nicdard/" ^ fname, expected_result))
 
 let gep_tests = prefix
   [ "gep0.ll", 1L

--- a/03/zikai.ml
+++ b/03/zikai.ml
@@ -1,4 +1,4 @@
-let prefix = "./compiler-design-eth-tests/03/zikai/"
+let prefix = Test_config.global_prefix ^ "./compiler-design-eth-tests/03/zikai/"
 
 let zikai_tests = [
     prefix ^ "nested_structs.ll", 16L

--- a/04/dbernhard.ml
+++ b/04/dbernhard.ml
@@ -1,6 +1,6 @@
 open Assert
 
-let prefix = "./compiler-design-eth-tests/04/dbernhard/"
+let prefix = Test_config.global_prefix ^ "./compiler-design-eth-tests/04/dbernhard/"
 
 let simple_tests = [
   (prefix ^ "simple_while.oat", "", "10")

--- a/04/nicdard.ml
+++ b/04/nicdard.ml
@@ -1,6 +1,6 @@
 (* Add path to test files *)
 let prefix = List.map (fun (fname, args, expected_result) -> 
-  ("./compiler-design-eth-tests/04/nicdard/" ^ fname, args, expected_result))
+  (Test_config.global_prefix ^ "./compiler-design-eth-tests/04/nicdard/" ^ fname, args, expected_result))
 
 let easy_tests = 
   [ ("easyrun0.oat", "", "10")

--- a/04/thbwd.ml
+++ b/04/thbwd.ml
@@ -1,6 +1,6 @@
 open Assert
 
-let prefix = "./compiler-design-eth-tests/04/thbwd/"
+let prefix = Test_config.global_prefix ^ "./compiler-design-eth-tests/04/thbwd/"
 
 let simple_tests = 
   [ (prefix ^ "nested_return_array.oat", "", "0")

--- a/README.md
+++ b/README.md
@@ -19,30 +19,32 @@ In any case, I will keep an eye at the course's forum in orther to gather all te
 ## Setup
 If you want to integrate these tests into your project instead of copying the files you can follow these steps:
 
-1. Clone this repo into the folder containing the `Makefile` of hw{2,3,4}.
-2. Adapt the Makefile to include these tests:
-```
+1. Clone this repo anywhere you like (let the path to the cloned repo be called `<repo_path>` and let `<project_path>` be the directory, which contains the makefile for the current homework)
+2. Create a symbolic link to `<repo_path>` called `sharedtests` in `<project_path>`
+3. Adapt the Makefile to include these tests:
+```diff
      main.native: gradedtests.ml studenttests.ml main.ml driver.ml backend.ml util/platform.ml
 -       ocamlbuild -Is util,x86,ll,grading -libs unix,str,nums main.native -use-menhir
-+       ocamlbuild -Is util,x86,ll,grading,compiler-design-eth-tests/0{2,3,4} -libs unix,str,nums main.native -use-menhir
++       ocamlbuild -Is util,x86,ll,grading,sharedtests,sharedtests/0{2,3,4,5,6} -libs unix,str,nums main.native -use-menhir
  
  main.byte: gradedtests.ml studenttests.ml main.ml driver.ml backend.ml util/platform.ml
 -       ocamlbuild -Is util,x86,ll,grading -libs unix,str,nums main.byte -use-menhir
-+       ocamlbuild -Is util,x86,ll,grading,compiler-design-eth-tests/0{2,3,4} -libs unix,str,nums main.byte -use-menhir
++       ocamlbuild -Is util,x86,ll,grading,sharedtests,sharedtests/0{2,3,4,5,6} -libs unix,str,nums main.byte -use-menhir
 ```
-
-2a. *Optional*: If you use merlin you should add these lines to the `.merlin` file:
-```
-+B _build/compiler-design-eth-tests
-+B _build/compiler-design-eth-tests/0{2,3,4}
-```
-3. Add our shared suite to `main.ml`:
-```
+(Note: depending on the makefile, the additional directories might need to be added at the top in a _DIRS_ variable or similar)
+4. Add our shared suite to `main.ml`:
+```diff
 -let suite = ref (Studenttests.provided_tests @ Gradedtests.graded_tests)
 +let suite = ref (
 +  Studenttests.provided_tests @
 +  Gradedtests.graded_tests @ 
 +  Sharedtests.shared_suite)
- ```
+```
+5. Edit the `global_prefix` in the file `Test_config` of this repo to represent the relative path from inside `<project_path>` to `<repo_path>`. By default it is setup such that `<repo_path>` and `<project_path>` have the same parent directory.
+6. *Optional*: If you use merlin you should add these lines to the `.merlin` file:
+```diff
++B _build/sharedtests/**
++S sharedtests/**
+```
 
 And now `make test` should also run our tests :) 

--- a/test_config.ml
+++ b/test_config.ml
@@ -1,0 +1,1 @@
+let global_prefix = "../"


### PR DESCRIPTION
as mentioned in #24 I've added a global prefix variable, such that this repo can be cloned anywhere and used by all homeworks

(sorry for being so late...)